### PR TITLE
chore(frontend): remove @pages alias from Vite config

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig(({ mode }) => {
         '@app': fileURLToPath(new URL('./src/app', import.meta.url)),
         '@shared': fileURLToPath(new URL('./src/shared', import.meta.url)),
         '@features': fileURLToPath(new URL('./src/features', import.meta.url)),
-        '@pages': fileURLToPath(new URL('./src/pages', import.meta.url)),
+        // Reintroduce '@pages' alias when a global pages directory exists.
         '@components': fileURLToPath(new URL('./src/components', import.meta.url)),
       },
     },


### PR DESCRIPTION
## Summary
- remove unused `@pages` alias from Vite config
- add note to reintroduce alias when a global pages directory exists

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find the config "react-app")

------
https://chatgpt.com/codex/tasks/task_e_68becb7cc278832db90283bed591e1a2