### PR TITLE
Ensure UI metadata queries refresh per user

### DIFF
--- a/frontend/src/contexts/UiContext.jsx
+++ b/frontend/src/contexts/UiContext.jsx
@@ -65,7 +65,7 @@ export function UiProvider({ children }) {
   const { user } = useAuth();
   const abacEnabled = String(import.meta.env.VITE_ENABLE_ABAC ?? 'false').toLowerCase() === 'true';
   const menusQ = useQuery(
-    ['ui:menus'],
+    ['ui:menus', user?.id],
     async () => {
       const res = await getUIMenus();
       return res.data?.data ?? [];
@@ -74,7 +74,7 @@ export function UiProvider({ children }) {
   );
 
   const permsQ = useQuery(
-    ['ui:perms'],
+    ['ui:perms', user?.id],
     async () => {
       const res = await getUIPermissions();
       return new Set(res.data?.data || []);
@@ -83,7 +83,7 @@ export function UiProvider({ children }) {
   );
 
   const featsQ = useQuery(
-    ['ui:features'],
+    ['ui:features', user?.id],
     async () => {
       const res = await getUIFeatures();
       return res.data?.data || {};
@@ -93,7 +93,7 @@ export function UiProvider({ children }) {
 
   const loading = menusQ.isLoading || permsQ.isLoading || featsQ.isLoading;
   const abacQ = useQuery(
-    ['ui:abac'],
+    ['ui:abac', user?.id],
     async () => {
       try {
         const res = await getAbacPolicies();

--- a/frontend/src/contexts/UiContext.querykeys.test.jsx
+++ b/frontend/src/contexts/UiContext.querykeys.test.jsx
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+
+const useQueryMock = vi.fn(() => ({ data: undefined, isLoading: false }));
+vi.mock('react-query', () => ({ useQuery: useQueryMock }));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: 1 } }) }));
+
+import { UiProvider } from './UiContext.jsx';
+
+describe('UiContext query keys', () => {
+  it('include user id for ui metadata queries', () => {
+    const div = document.createElement('div');
+    act(() => {
+      createRoot(div).render(<UiProvider>test</UiProvider>);
+    });
+    const keys = useQueryMock.mock.calls.map(c => c[0]);
+    expect(keys).toContainEqual(['ui:menus', 1]);
+    expect(keys).toContainEqual(['ui:perms', 1]);
+    expect(keys).toContainEqual(['ui:features', 1]);
+    expect(keys).toContainEqual(['ui:abac', 1]);
+  });
+});


### PR DESCRIPTION
## Summary
- include `user.id` in React Query keys for menus, permissions, features, and ABAC policies
- add test to confirm user ID is part of metadata query keys

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config "react-app")*


------
https://chatgpt.com/codex/tasks/task_e_68bef6095344832da49a4f91152df7f0