### PR TITLE
Export useAuth hook from AuthContext

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -232,6 +232,8 @@ export const AuthProvider = ({ children }) => {
   );
 };
 
+export const useAuth = () => useContext(AuthContext);
+
 // const value = {
 //   user,
 //   loading,


### PR DESCRIPTION
## Summary
- add missing `useAuth` hook export in AuthContext so other contexts can access auth state

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching vitest)*
- `npm run lint` *(fails: ESLint couldn't find config "react-app")*


------
https://chatgpt.com/codex/tasks/task_e_68bef8bf49b0832dad718d6994675a24