### PR TITLE
Guard permission hydration with elevated roles

### DIFF
--- a/backend/src/api/v2/features/auth/auth.service.js
+++ b/backend/src/api/v2/features/auth/auth.service.js
@@ -121,8 +121,10 @@ class AuthService {
         await executeQuery('UPDATE users SET last_login = NOW() WHERE id = ?', [userRow.id]);
 
         const user = sanitizeUser(userRow);
+        // expose permissions to clients so they don't need to look up roles
         user.effectivePermissions = permissionNames;
-        
+        user.permission_names = permissionNames;
+
         return { user, accessToken, refreshToken: session.refreshToken };
     }
 

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -78,8 +78,9 @@ export const AuthProvider = ({ children }) => {
       // The backend should supply `effectivePermissions` during login; the
       // frontend no longer falls back to fetching roles which required
       // elevated rights and caused 403 errors for non-admin users.
-      // Resolve from roles API if we still have none
-      if (nameBag.size === 0) {
+      // Resolve from roles API only for elevated users or if explicitly allowed
+      // via a flag on the user object (e.g. during setup or debugging)
+      if (nameBag.size === 0 && (elevated || u?.allowRoleFetch)) {
         const roleIds = extractRoleIds(u);
         for (const rid of roleIds) {
           try {


### PR DESCRIPTION
## Summary
- Avoid role-by-role permission hydration unless user is elevated or explicitly allowed
- Login API now returns `effectivePermissions` and `permission_names`

## Testing
- `npm test` (backend) *(fails: jest not found)*
- `npm test` (frontend) *(fails: vitest not found)*
- `npm run lint` (frontend) *(fails: ESLint config react-app not found)*

------
https://chatgpt.com/codex/tasks/task_e_68befb0f1cdc832d83aa67773fd0272c