### PR TITLE
Default deny for invalid ABAC conditions

### DIFF
--- a/frontend/src/contexts/UiContext.jsx
+++ b/frontend/src/contexts/UiContext.jsx
@@ -26,7 +26,7 @@ export function evaluate(policy, ctx = {}) {
       conds = null;
     }
   }
-  if (!conds) return true;
+  if (!conds) return false;
 
   const get = (path) => path.split('.').reduce((acc, k) => (acc ? acc[k] : undefined), ctx);
 
@@ -41,7 +41,7 @@ export function evaluate(policy, ctx = {}) {
 
   // Minimal JSONLogic: {"==": [ {"var":"field"}, value ] } and {"in": [ {"var":"field"}, [..] ]}
   const evalJson = (rule) => {
-    if (!rule || typeof rule !== 'object') return true;
+    if (!rule || typeof rule !== 'object') return false;
     if (rule.var) return get(String(rule.var));
     if (rule['==']) {
       const [a, b] = rule['=='];

--- a/frontend/src/contexts/UiContext.test.jsx
+++ b/frontend/src/contexts/UiContext.test.jsx
@@ -11,5 +11,15 @@ describe('evaluate', () => {
     const policy = { conditions: { '==': [{ var: 'flag' }, { unsupported: true }] } };
     expect(evaluate(policy, { flag: true })).toBe(false);
   });
+
+  it('denies access when conditions are missing', () => {
+    const policy = {};
+    expect(evaluate(policy, { user: { role: 'admin' } })).toBe(false);
+  });
+
+  it('denies access for invalid JSON condition strings', () => {
+    const policy = { condition: '{invalid}' };
+    expect(evaluate(policy, { user: { role: 'admin' } })).toBe(false);
+  });
 });
 


### PR DESCRIPTION
## Summary
- Deny access when ABAC conditions are missing or invalid
- Harden JSON rule evaluation to default deny
- Test that missing or malformed conditions deny access

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden fetching repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68befd62aae4832d96d7120f9e12e3c9