### PR TITLE
Fix policy engine handling of malformed nodes

### DIFF
--- a/backend/src/api/v2/services/policy.engine.js
+++ b/backend/src/api/v2/services/policy.engine.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { executeQuery } = require('../../../../utils/database');
+const logger = require('../../../../utils/logger');
 
 let CACHE = { at: 0, items: [] };
 const TTL_MS = 30 * 1000;
@@ -34,7 +35,7 @@ function toSet(x) {
 }
 
 function evalNode(node, ctx) {
-  if (!node || typeof node !== 'object') return true;
+  if (!node || typeof node !== 'object') return false;
   if (node.all) return node.all.every(n => evalNode(n, ctx));
   if (node.any) return node.any.some(n => evalNode(n, ctx));
 
@@ -66,7 +67,8 @@ function evalNode(node, ctx) {
     const v = getPath(ctx, node.branchEquals) ?? node.branchEquals;
     return Number(ctx.branchId) === Number(v);
   }
-  return true;
+  logger.warn('Unsupported policy node encountered', node);
+  return false;
 }
 
 function evaluate(policies, ctx) {

--- a/backend/src/api/v2/services/policy.engine.test.js
+++ b/backend/src/api/v2/services/policy.engine.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { evaluate } = require('./policy.engine');
+
+describe('policy engine safety', () => {
+  const ctx = { user: { org_id: 1, permissions: [] }, branchId: 1 };
+
+  test('does not allow access when conditions are null', () => {
+    const policies = [{ effect: 'allow', conditions: null }];
+    const result = evaluate(policies, ctx);
+    expect(result.decision).toBe('neutral');
+  });
+
+  test('does not allow access when conditions are not objects', () => {
+    const policies = [{ effect: 'allow', conditions: 'bad' }];
+    const result = evaluate(policies, ctx);
+    expect(result.decision).toBe('neutral');
+  });
+
+  test('does not allow access for unsupported node types', () => {
+    const policies = [{ effect: 'allow', conditions: { foo: 'bar' } }];
+    const result = evaluate(policies, ctx);
+    expect(result.decision).toBe('neutral');
+  });
+});
+


### PR DESCRIPTION
## Summary
- default deny when policy node is null or non-object
- warn and deny on unsupported policy node types
- add tests to ensure malformed policies never allow access

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/glob)*

------
https://chatgpt.com/codex/tasks/task_e_68bf01600fd4832d9fc9262aad1b21e9