### PR TITLE
Guard permission hydration and skip role fetch for non-elevated users

### DIFF
--- a/frontend/src/contexts/AuthContext.test.jsx
+++ b/frontend/src/contexts/AuthContext.test.jsx
@@ -1,0 +1,55 @@
+/* @vitest-environment jsdom */
+
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { act } from 'react-dom/test-utils';
+import ReactDOM from 'react-dom/client';
+import api, { getUIBootstrap, login as loginApi } from '../services/api';
+import { AuthProvider, useAuth } from './AuthContext';
+
+vi.mock('../services/api', () => ({
+  __esModule: true,
+  default: {
+    getRoleById: vi.fn(),
+  },
+  getUIBootstrap: vi.fn(),
+  setActiveBranchId: vi.fn(),
+  login: vi.fn(),
+}));
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not fetch roles for non-elevated users with permissions', async () => {
+    loginApi.mockResolvedValue({
+      data: { data: { user: { id: 1, permission_names: ['x.read'] } } },
+    });
+    getUIBootstrap.mockResolvedValue({ data: { data: {} } });
+
+    let loginFn;
+    function Child() {
+      const { login } = useAuth();
+      loginFn = login;
+      return null;
+    }
+
+    const div = document.createElement('div');
+    const root = ReactDOM.createRoot(div);
+    await act(async () => {
+      root.render(
+        <AuthProvider>
+          <Child />
+        </AuthProvider>,
+      );
+    });
+
+    await act(async () => {
+      await loginFn({ username: 'u', password: 'p' });
+    });
+
+    expect(api.getRoleById).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `isElevatedUser` helper and guard role-based permission hydration
- rely on backend-provided `effectivePermissions`/`permission_names`
- add test ensuring non-admin users don't trigger `/roles/:id` lookups

## Testing
- `npm test` *(fails: vitest not found, npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc86c0ab8832da0493f19ad41fbc3