### PR TITLE
Default deny for malformed ABAC policies

### DIFF
--- a/frontend/src/contexts/UiContext.jsx
+++ b/frontend/src/contexts/UiContext.jsx
@@ -26,6 +26,7 @@ export function evaluate(policy, ctx = {}) {
       conds = null;
     }
   }
+  // Default deny when no conditions provided
   if (!conds) return false;
 
   const get = (path) => path.split('.').reduce((acc, k) => (acc ? acc[k] : undefined), ctx);
@@ -50,10 +51,10 @@ export function evaluate(policy, ctx = {}) {
     if (rule.in) {
       const [a, arr] = rule.in;
       const v = evalJson(a);
-      const list = Array.isArray(arr) ? arr : [];
-      return list.includes(v);
+      if (!Array.isArray(arr)) return false;
+      return arr.includes(v);
     }
-    // Default deny if we can't evaluate
+    // Unsupported operations default to deny
     return false;
   };
   return evalJson(conds);

--- a/frontend/src/contexts/UiContext.test.jsx
+++ b/frontend/src/contexts/UiContext.test.jsx
@@ -21,5 +21,20 @@ describe('evaluate', () => {
     const policy = { condition: '{invalid}' };
     expect(evaluate(policy, { user: { role: 'admin' } })).toBe(false);
   });
+
+  it('denies access for unknown operators', () => {
+    const policy = { conditions: { unknown: [{ var: 'role' }, 'admin'] } };
+    expect(evaluate(policy, { role: 'admin' })).toBe(false);
+  });
+
+  it('denies access when "in" operand is not an array', () => {
+    const policy = { conditions: { in: [{ var: 'role' }, 'admin'] } };
+    expect(evaluate(policy, { role: 'admin' })).toBe(false);
+  });
+
+  it('denies access when conditions are not objects', () => {
+    const policy = { conditions: 42 };
+    expect(evaluate(policy, { role: 'admin' })).toBe(false);
+  });
 });
 


### PR DESCRIPTION
## Summary
- Harden ABAC evaluation by defaulting to deny when no conditions or unsupported JSONLogic structures are provided
- Add unit tests for malformed ABAC policies to ensure access is denied

## Testing
- `cd frontend && npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd1c37cd0832dbb7e1d82d892e160