### PR TITLE
chore: deny invalid ABAC conditions

### DIFF
--- a/frontend/src/contexts/UiContext.jsx
+++ b/frontend/src/contexts/UiContext.jsx
@@ -26,7 +26,7 @@ export function evaluate(policy, ctx = {}) {
       conds = null;
     }
   }
-  // Default deny when no conditions provided
+  // Default deny when no conditions provided or parsed value is falsy
   if (!conds) return false;
 
   const get = (path) => path.split('.').reduce((acc, k) => (acc ? acc[k] : undefined), ctx);
@@ -42,7 +42,9 @@ export function evaluate(policy, ctx = {}) {
 
   // Minimal JSONLogic: {"==": [ {"var":"field"}, value ] } and {"in": [ {"var":"field"}, [..] ]}
   const evalJson = (rule) => {
+    // Unknown or non-object structures default to deny
     if (!rule || typeof rule !== 'object') return false;
+    if (Array.isArray(rule)) return false;
     if (rule.var) return get(String(rule.var));
     if (rule['==']) {
       const [a, b] = rule['=='];

--- a/frontend/src/contexts/UiContext.test.jsx
+++ b/frontend/src/contexts/UiContext.test.jsx
@@ -22,6 +22,16 @@ describe('evaluate', () => {
     expect(evaluate(policy, { user: { role: 'admin' } })).toBe(false);
   });
 
+  it('denies access when condition string is empty', () => {
+    const policy = { condition: '' };
+    expect(evaluate(policy, { user: { role: 'admin' } })).toBe(false);
+  });
+
+  it('denies access when conditions are null', () => {
+    const policy = { conditions: null };
+    expect(evaluate(policy, { role: 'admin' })).toBe(false);
+  });
+
   it('denies access for unknown operators', () => {
     const policy = { conditions: { unknown: [{ var: 'role' }, 'admin'] } };
     expect(evaluate(policy, { role: 'admin' })).toBe(false);


### PR DESCRIPTION
## Summary
- ensure ABAC evaluator denies when conditions are missing or malformed
- test evaluator for empty and null conditions

## Testing
- `npm test --prefix frontend` *(fails: MISSING DEP  Can not find dependency 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_68bfed6ab780832d94ddea9a41aec05c