### PR TITLE
feat: delay rendering until permissions load

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -51,6 +51,7 @@ export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [permissionNames, setPermissionNames] = useState([]); // ['pos.discount.edit', ...]
   const [loading, setLoading] = useState(true);
+  // separate loading flag for permission hydration
   const [permLoading, setPermLoading] = useState(true);
 
   // Branch mgmt
@@ -242,7 +243,7 @@ export const AuthProvider = ({ children }) => {
 
   return (
     <AuthContext.Provider value={value}>
-      {!loading && !permLoading && children}
+      {!loading && !permLoading ? children : null}
     </AuthContext.Provider>
   );
 };


### PR DESCRIPTION
## Summary
- clarify separate `permLoading` state for permission hydration
- render AuthProvider children only after permissions finish loading

## Testing
- `npm test` *(fails: Can not find dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68bff1f5a5c4832db1a7e10d4146c02e