### PR TITLE
Avoid empty filter params in purchase pages

### DIFF
--- a/frontend/src/features/purchases/pages/PurchaseOrders.jsx
+++ b/frontend/src/features/purchases/pages/PurchaseOrders.jsx
@@ -62,12 +62,17 @@ const PurchaseOrdersPage = () => {
   // 3. Update the useQuery hook to be branch-aware
   const { data, isLoading, error } = useQuery(
     ['purchaseOrders', page, rowsPerPage, filters, currentBranch?.id],
-    () => api.getPurchaseOrders({
-      page: page + 1,
-      limit: rowsPerPage,
-      branch_id: currentBranch?.id, // Always pass the current branch ID
-      ...filters
-    }),
+    () => {
+      const params = {
+        page: page + 1,
+        limit: rowsPerPage,
+        branch_id: currentBranch?.id, // Always pass the current branch ID
+      };
+      if (filters.supplier_id) params.supplier_id = filters.supplier_id;
+      if (filters.status) params.status = filters.status;
+      if (filters.search) params.search = filters.search;
+      return api.getPurchaseOrders(params);
+    },
     {
       enabled: !!currentBranch, // Only run query if a branch is selected
       keepPreviousData: true,

--- a/frontend/src/features/purchases/pages/Purchases.jsx
+++ b/frontend/src/features/purchases/pages/Purchases.jsx
@@ -52,12 +52,16 @@ const PurchasesPage = () => {
   // 3. Update the useQuery hook to be branch-aware
   const { data, isLoading, error } = useQuery(
     ['purchases', page, rowsPerPage, filters, currentBranch?.id],
-    () => api.getAllPurchases({
-      page: page + 1,
-      limit: rowsPerPage,
-      branch_id: currentBranch?.id, // Always pass the current branch ID
-      ...filters
-    }),
+    () => {
+      const params = {
+        page: page + 1,
+        limit: rowsPerPage,
+        branch_id: currentBranch?.id, // Always pass the current branch ID
+      };
+      if (filters.supplier_id) params.supplier_id = filters.supplier_id;
+      if (filters.search) params.search = filters.search;
+      return api.getAllPurchases(params);
+    },
     {
       enabled: !!currentBranch, // Only run query if a branch is selected
       keepPreviousData: true,


### PR DESCRIPTION
## Summary
- build purchase order params without empty filters
- build purchase entry params without empty filters

## Testing
- `npm test` *(fails: Can not find dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68c024bf6418832db448aa7560248c8e