### PR TITLE
feat: manage role feature overrides

### DIFF
--- a/backend/repositories/sessions.js
+++ b/backend/repositories/sessions.js
@@ -134,6 +134,14 @@ async function revokeSessionBySid(sid, reason = null) {
   );
 }
 
+async function revokeSessionsByRoleId(roleId, reason = null) {
+  if (!roleId) return;
+  await executeQuery(
+    `UPDATE auth_sessions SET revoked_at = NOW(), revoke_reason = ? WHERE role_id = ? AND revoked_at IS NULL`,
+    [reason, roleId]
+  );
+}
+
 /** Rotate refresh token in-place (refresh flow). */
 async function rotateRefreshToken(refreshToken) {
   if (!refreshToken) return null;
@@ -189,6 +197,7 @@ module.exports = {
   touchSessionLastSeen,
   revokeSessionBySid,
   rotateRefreshToken,
+  revokeSessionsByRoleId,
 };
 
 

--- a/backend/src/api/v2/features/roles/roles.controller.js
+++ b/backend/src/api/v2/features/roles/roles.controller.js
@@ -37,6 +37,25 @@ class RolesController {
     } catch (e) { next(e); }
   }
 
+  async getFeatures(req, res, next) {
+    try {
+      const roleId = Number(req.params.id);
+      const data = await Service.getRoleFeatures(roleId);
+      res.json({ success: true, data });
+    } catch (e) { next(e); }
+  }
+
+  async updateFeatures(req, res, next) {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) return res.status(400).json({ success: false, errors: errors.array() });
+      const roleId = Number(req.params.id);
+      const features = req.body || {};
+      await Service.updateRoleFeatures(roleId, features);
+      res.json({ success: true, message: 'Role features updated' });
+    } catch (e) { next(e); }
+  }
+
   async update(req, res, next) {
     try {
       const errors = validationResult(req);

--- a/backend/src/api/v2/features/roles/roles.routes.js
+++ b/backend/src/api/v2/features/roles/roles.routes.js
@@ -27,4 +27,9 @@ router.put('/:id', abacEnforce({ anyPermissions: ['roles:manage'] }), validate([
   body('permissions').isArray().withMessage('permissions must be an array'),
 ]), Controller.update);
 
+router.get('/:id/features', abacEnforce({ anyPermissions: ['roles:read', 'roles:manage'] }),
+  validate([param('id').isInt({ min: 1 })]), Controller.getFeatures);
+router.put('/:id/features', abacEnforce({ anyPermissions: ['roles:manage'] }),
+  validate([param('id').isInt({ min: 1 })]), Controller.updateFeatures);
+
 module.exports = router;

--- a/backend/src/api/v2/features/roles/roles.service.js
+++ b/backend/src/api/v2/features/roles/roles.service.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { executeQuery, getConnection } = require('../../../../../utils/database');
+const { revokeSessionsByRoleId } = require('../../../../../repositories/sessions');
 
 function groupPermissionsByCategory(rows) {
   const out = {};
@@ -71,11 +72,69 @@ async function updateRolePermissions(roleId, { name, description, permissions = 
   }
 }
 
+function parseJson(value, fallback = null) {
+  try { return JSON.parse(value); } catch { return fallback; }
+}
+
+async function getRoleFeatures(roleId) {
+  const rows = await executeQuery(
+    `SELECT f.feature_key, f.default_value, f.description, o.value AS override
+       FROM features f
+       LEFT JOIN role_feature_overrides o
+         ON o.feature_key = f.feature_key AND o.role_id = ?
+      ORDER BY f.feature_key`,
+    [roleId]
+  );
+  return rows.map(r => ({
+    key: r.feature_key,
+    description: r.description,
+    default_value: parseJson(r.default_value, false),
+    override: r.override != null ? parseJson(r.override, null) : null,
+  }));
+}
+
+async function updateRoleFeatures(roleId, features = {}) {
+  const conn = await getConnection();
+  let changed = false;
+  try {
+    await conn.beginTransaction();
+    for (const [key, val] of Object.entries(features)) {
+      if (val === null || typeof val === 'undefined') {
+        const [res] = await conn.execute(
+          `DELETE FROM role_feature_overrides WHERE role_id = ? AND feature_key = ?`,
+          [roleId, key]
+        );
+        if (res.affectedRows) changed = true;
+      } else {
+        const jsonVal = JSON.stringify(val);
+        const [res] = await conn.execute(
+          `INSERT INTO role_feature_overrides (role_id, feature_key, value)
+             VALUES (?, ?, ?)
+             ON DUPLICATE KEY UPDATE value = VALUES(value)`,
+          [roleId, key, jsonVal]
+        );
+        if (res.affectedRows) changed = true;
+      }
+    }
+    await conn.commit();
+  } catch (e) {
+    try { await conn.rollback(); } catch {}
+    throw e;
+  } finally {
+    try { conn.release(); } catch {}
+  }
+  if (changed) {
+    try { await revokeSessionsByRoleId(roleId, 'Role features updated'); } catch {}
+  }
+}
+
 module.exports = {
   listPermissions,
   createPermission,
   listRoles,
   getRole,
   updateRolePermissions,
+  getRoleFeatures,
+  updateRoleFeatures,
 };
 

--- a/frontend/src/features/roles/api.js
+++ b/frontend/src/features/roles/api.js
@@ -4,6 +4,8 @@ import {
   updateRole as updateRoleSvc,
   getAllPermissions as listPermissionsSvc,
   createPermission as createPermissionSvc,
+  getRoleFeatures as getRoleFeaturesSvc,
+  updateRoleFeatures as updateRoleFeaturesSvc,
 } from '@shared/api';
 
 export const listRoles = (params) => getAllRolesSvc(params);
@@ -11,4 +13,6 @@ export const getRoleById = (id) => getRoleByIdSvc(id);
 export const updateRole = (id, payload) => updateRoleSvc(id, payload);
 export const listPermissions = () => listPermissionsSvc();
 export const createPermission = (payload) => createPermissionSvc(payload);
+export const getRoleFeatures = (id) => getRoleFeaturesSvc(id);
+export const updateRoleFeatures = (id, payload) => updateRoleFeaturesSvc(id, payload);
 

--- a/frontend/src/features/roles/components/FeaturesFormModal.jsx
+++ b/frontend/src/features/roles/components/FeaturesFormModal.jsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  CircularProgress,
+  FormControlLabel,
+  Switch,
+  Typography,
+} from '@mui/material';
+import toast from 'react-hot-toast';
+import { useRoleFeatures, useUpdateRoleFeatures } from '@/features/roles/hooks';
+
+const FeaturesFormModal = ({ open, onClose, role }) => {
+  const { data, isLoading } = useRoleFeatures(role?.id, { enabled: open && !!role });
+  const updateMutation = useUpdateRoleFeatures(role?.id);
+  const [features, setFeatures] = useState([]);
+
+  useEffect(() => {
+    if (data) {
+      const mapped = data.map((f) => ({
+        key: f.key,
+        description: f.description,
+        defaultValue: Boolean(f.default_value),
+        value: f.override != null ? Boolean(f.override) : Boolean(f.default_value),
+      }));
+      setFeatures(mapped);
+    } else if (!open) {
+      setFeatures([]);
+    }
+  }, [data, open]);
+
+  const handleToggle = (key) => (e) => {
+    const checked = e.target.checked;
+    setFeatures((prev) => prev.map((f) => (f.key === key ? { ...f, value: checked } : f)));
+  };
+
+  const handleSave = () => {
+    const payload = {};
+    features.forEach((f) => {
+      if (f.value === f.defaultValue) payload[f.key] = null;
+      else payload[f.key] = f.value;
+    });
+    updateMutation.mutate(payload, {
+      onSuccess: () => {
+        toast.success('Role features updated');
+        onClose();
+      },
+      onError: (err) => toast.error(err?.response?.data?.message || 'Failed to update role features'),
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Manage Features for "{role?.name}"</DialogTitle>
+      <DialogContent dividers>
+        {isLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress /></Box>
+        ) : (
+          <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: 2 }}>
+            {features.map((f) => (
+              <FormControlLabel
+                key={f.key}
+                control={<Switch checked={!!f.value} onChange={handleToggle(f.key)} />}
+                label={f.description || f.key}
+              />
+            ))}
+            {!features.length && (
+              <Typography variant="body2" color="text.secondary">No features found.</Typography>
+            )}
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={updateMutation.isLoading}>Cancel</Button>
+        <Button variant="contained" onClick={handleSave} disabled={updateMutation.isLoading}>
+          {updateMutation.isLoading ? 'Saving...' : 'Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default FeaturesFormModal;

--- a/frontend/src/features/roles/hooks.js
+++ b/frontend/src/features/roles/hooks.js
@@ -1,5 +1,13 @@
 import { useQuery, useMutation, useQueryClient } from 'react-query';
-import { listRoles, getRoleById, updateRole, listPermissions, createPermission } from './api';
+import {
+  listRoles,
+  getRoleById,
+  updateRole,
+  listPermissions,
+  createPermission,
+  getRoleFeatures,
+  updateRoleFeatures,
+} from './api';
 
 export function useRoles(params) {
   return useQuery(['roles', params], () => listRoles(params).then(r => r.data?.data ?? r.data));
@@ -27,6 +35,19 @@ export function useCreatePermission() {
   const qc = useQueryClient();
   return useMutation((payload) => createPermission(payload).then(r => r.data?.data ?? r.data), {
     onSuccess: () => qc.invalidateQueries(['roles:permissions'])
+  });
+}
+
+export function useRoleFeatures(id, options = {}) {
+  return useQuery(['roleFeatures', id], () => getRoleFeatures(id).then(r => r.data?.data ?? r.data), { enabled: !!id, ...options });
+}
+
+export function useUpdateRoleFeatures(id) {
+  const qc = useQueryClient();
+  return useMutation((payload) => updateRoleFeatures(id, payload).then(r => r.data?.data ?? r.data), {
+    onSuccess: () => {
+      qc.invalidateQueries(['roleFeatures', id]);
+    }
   });
 }
 

--- a/frontend/src/features/roles/pages/Roles.jsx
+++ b/frontend/src/features/roles/pages/Roles.jsx
@@ -17,9 +17,11 @@ import toast from 'react-hot-toast';
 import { useQueryClient } from 'react-query';
 import { useRoles, useUpdateRole } from '@/features/roles/hooks';
 import PermissionsFormModal from '@/features/roles/components/PermissionsFormModal';
+import FeaturesFormModal from '@/features/roles/components/FeaturesFormModal';
 
 const RolesPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isFeaturesOpen, setIsFeaturesOpen] = useState(false);
   const [selectedRole, setSelectedRole] = useState(null);
   const queryClient = useQueryClient();
 
@@ -27,7 +29,9 @@ const RolesPage = () => {
   const updateRoleMutation = useUpdateRole(selectedRole?.id);
 
   const handleManagePermissions = (role) => { setSelectedRole(role); setIsModalOpen(true); };
+  const handleManageFeatures = (role) => { setSelectedRole(role); setIsFeaturesOpen(true); };
   const handleModalClose = () => { setIsModalOpen(false); setSelectedRole(null); };
+  const handleFeaturesClose = () => { setIsFeaturesOpen(false); setSelectedRole(null); };
   const handleFormSubmit = (formData) => {
     updateRoleMutation.mutate(formData, {
       onSuccess: () => { toast.success('Role permissions updated successfully!'); setIsModalOpen(false); },
@@ -57,6 +61,7 @@ const RolesPage = () => {
                 <TableCell>{role.description || '—'}</TableCell>
                 <TableCell align="right">
                   <Button size="small" variant="contained" onClick={() => handleManagePermissions(role)}>Permissions</Button>
+                  <Button size="small" sx={{ ml: 1 }} onClick={() => handleManageFeatures(role)}>Features</Button>
                 </TableCell>
               </TableRow>
             ))}
@@ -65,6 +70,7 @@ const RolesPage = () => {
       </TableContainer>
 
       <PermissionsFormModal open={isModalOpen} onClose={handleModalClose} onSubmit={handleFormSubmit} role={selectedRole} isLoading={updateRoleMutation.isLoading} />
+      <FeaturesFormModal open={isFeaturesOpen} onClose={handleFeaturesClose} role={selectedRole} />
     </Box>
   );
 };

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -447,6 +447,8 @@ export const api = {
   updateRole: (id, data) => axios.put(`${API_PREFIX}/roles/${id}`, data),
   getAllPermissions: () => axios.get(`${API_PREFIX}/roles/permissions`),
   createPermission: (payload) => axios.post(`${API_PREFIX}/roles/permissions`, payload),
+  getRoleFeatures: (id) => axios.get(`${API_PREFIX}/roles/${id}/features`),
+  updateRoleFeatures: (id, data) => axios.put(`${API_PREFIX}/roles/${id}/features`, data),
 
   // ABAC policies
   getAbacPolicies: () => axios.get(`${API_PREFIX}/abac/policies`),


### PR DESCRIPTION
## Summary
- add service helpers and routes to manage role feature overrides
- surface role features in UI with switches
- revoke role sessions when feature flags change

## Testing
- `npm test --prefix backend` *(fails: jest: not found)*
- `npm test --prefix frontend` *(fails: UiContext.querykeys.test.jsx module mocking error)*

------
https://chatgpt.com/codex/tasks/task_e_68c14d72a6c8832da0465fbb29927343