### PR TITLE
refactor: build menu tree using menuBuilder

### DIFF
--- a/backend/utils/menuBuilder.test.js
+++ b/backend/utils/menuBuilder.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+jest.mock('./database', () => ({
+  executeQuery: jest.fn(),
+}));
+
+const { executeQuery } = require('./database');
+const { buildForUser } = require('./menuBuilder');
+
+describe('menuBuilder buildForUser', () => {
+  const menus = [
+    { id: 1, parent_id: null, code: 'dashboard', label: 'Dashboard', route_path: '/dashboard', icon: null, sort_order: 1, is_active: 1 },
+    { id: 2, parent_id: null, code: 'admin', label: 'Admin', route_path: '/admin', icon: null, sort_order: 2, is_active: 1 },
+  ];
+
+  const menuPerms = [
+    { menu_id: 2, permission_name: 'admin:access' },
+  ];
+
+  beforeEach(() => {
+    executeQuery.mockReset();
+    executeQuery.mockImplementation((sql, params) => {
+      if (sql.includes('FROM menus')) {
+        return Promise.resolve(menus);
+      }
+      if (sql.includes('FROM menu_permissions')) {
+        return Promise.resolve(menuPerms);
+      }
+      if (sql.includes('FROM role_permissions')) {
+        const roleId = params[0];
+        if (roleId === 1) {
+          return Promise.resolve([{ name: 'admin:access' }]);
+        }
+        if (roleId === 2) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([]);
+    });
+  });
+
+  test('includes gated menus when role has permission', async () => {
+    const tree = await buildForUser({ role_id: 1 });
+    expect(tree).toEqual([
+      { key: 'dashboard', label: 'Dashboard', path: '/dashboard', icon: null, sort_order: 1, children: [] },
+      { key: 'admin', label: 'Admin', path: '/admin', icon: null, sort_order: 2, children: [] },
+    ]);
+  });
+
+  test('excludes gated menus when role lacks permission', async () => {
+    const tree = await buildForUser({ role_id: 2 });
+    expect(tree).toEqual([
+      { key: 'dashboard', label: 'Dashboard', path: '/dashboard', icon: null, sort_order: 1, children: [] },
+    ]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- use shared menuBuilder to build menus for user sessions
- remove legacy menu snapshot helper in auth service
- add unit tests verifying menu tree respects role permissions

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c189048c30832da57141d8a64c5bcb