### PR TITLE
feat(frontend): export role feature APIs

### DIFF
--- a/frontend/src/features/roles/hooks.js
+++ b/frontend/src/features/roles/hooks.js
@@ -5,9 +5,8 @@ import {
   updateRole,
   listPermissions,
   createPermission,
-  getRoleFeatures,
-  updateRoleFeatures,
 } from './api';
+import { getRoleFeatures, updateRoleFeatures } from '@shared/api';
 
 export function useRoles(params) {
   return useQuery(['roles', params], () => listRoles(params).then(r => r.data?.data ?? r.data));

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -599,6 +599,8 @@ export const getRoleById = api.getRoleById;
 export const updateRole = api.updateRole;
 export const getAllPermissions = api.getAllPermissions;
 export const createPermission = api.createPermission;
+export const getRoleFeatures = api.getRoleFeatures;
+export const updateRoleFeatures = api.updateRoleFeatures;
 
 // UI helpers (menus / permissions / features)
 export const getUIMenus = () => axios.get(`${API_PREFIX}/ui/menus`);


### PR DESCRIPTION
## Summary
- export role feature API helpers from shared api
- use shared api for role feature hooks

## Testing
- `npm run lint` (fails: ESLint couldn't find config "react-app")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c19d53bd0c832d8b477c8eedc4af96